### PR TITLE
Import matplotlib only if required to avoid dependency issues with Tkinter

### DIFF
--- a/pyflux/arma/arimax.py
+++ b/pyflux/arma/arimax.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 from patsy import dmatrices, dmatrix, demo_data
 
@@ -317,6 +316,7 @@ class ARIMAX(tsm.TSM):
         """ 
         Plots the fit of the model against the data
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
         plt.figure(figsize=figsize)
@@ -348,7 +348,8 @@ class ARIMAX(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -435,7 +436,8 @@ class ARIMAX(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/arma/arma.py
+++ b/pyflux/arma/arma.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -292,6 +291,7 @@ class ARIMA(tsm.TSM):
         """ 
         Plots the fit of the model against the data
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
         plt.figure(figsize=figsize)
@@ -320,7 +320,8 @@ class ARIMA(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -398,7 +399,8 @@ class ARIMA(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
         plt.figure(figsize=figsize)

--- a/pyflux/covariances.py
+++ b/pyflux/covariances.py
@@ -1,6 +1,5 @@
 import numpy as np
 from math import sqrt
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 # Returns sample autocovariance of two np arrays (stationarity assumed)
@@ -19,6 +18,8 @@ def acf(x,lag=0):
 
 # Returns acf plot
 def acf_plot(x,max_lag=10):
+    import matplotlib.pyplot as plt
+
     plt.figure(figsize=(8,4))
     ax = plt.subplot(111)
     ax.set_axis_bgcolor((0.2,0.2,0.2))

--- a/pyflux/distributions/distributions.py
+++ b/pyflux/distributions/distributions.py
@@ -1,6 +1,4 @@
 import scipy.stats as ss
-import matplotlib.mlab as mlab
-import matplotlib.pyplot as plt
 import numpy as np
 
 class q_Normal(object):
@@ -125,6 +123,9 @@ class q_Normal(object):
         """
         Plots the PDF of the Normal Distribution
         """
+        import matplotlib.pyplot as plt
+        import matplotlib.mlab as mlab
+
         x = np.linspace(self.loc-np.exp(self.scale)*3.5,self.loc+np.exp(self.scale)*3.5,100)
         plt.plot(x,mlab.normpdf(x,self.loc,np.exp(self.scale)))
         plt.show()

--- a/pyflux/ensembles/mixture_of_experts.py
+++ b/pyflux/ensembles/mixture_of_experts.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import numpy as np
-import matplotlib.pyplot as plt
 
 class Aggregate():
     """ Aggregation Algorithm
@@ -293,6 +292,8 @@ class Aggregate():
         ----------
         - A plot of the weights for each model constituent over time
         """
+        import matplotlib.pyplot as plt
+
         figsize = kwargs.get('figsize',(10,7))
 
         weights, _, _ = self.run(h=h)

--- a/pyflux/garch/egarch.py
+++ b/pyflux/garch/egarch.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -327,6 +326,7 @@ class EGARCH(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -350,6 +350,7 @@ class EGARCH(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -383,7 +384,8 @@ class EGARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -466,7 +468,8 @@ class EGARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/garch/egarchm.py
+++ b/pyflux/garch/egarchm.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -332,6 +331,7 @@ class EGARCHM(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -366,7 +366,8 @@ class EGARCHM(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -449,7 +450,8 @@ class EGARCHM(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/garch/egarchmreg.py
+++ b/pyflux/garch/egarchmreg.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 from patsy import dmatrices, dmatrix, demo_data
 
@@ -364,6 +363,7 @@ class EGARCHMReg(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -401,7 +401,8 @@ class EGARCHMReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -490,7 +491,8 @@ class EGARCHMReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/garch/garch.py
+++ b/pyflux/garch/garch.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -281,6 +280,7 @@ class GARCH(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -314,7 +314,8 @@ class GARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -397,7 +398,8 @@ class GARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/garch/lmegarch.py
+++ b/pyflux/garch/lmegarch.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -351,6 +350,7 @@ class LMEGARCH(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -385,7 +385,8 @@ class LMEGARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -470,7 +471,8 @@ class LMEGARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/garch/segarch.py
+++ b/pyflux/garch/segarch.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -352,6 +351,7 @@ class SEGARCH(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -386,7 +386,8 @@ class SEGARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -470,7 +471,8 @@ class SEGARCH(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/garch/segarchm.py
+++ b/pyflux/garch/segarchm.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -376,6 +375,7 @@ class SEGARCHM(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -410,7 +410,8 @@ class SEGARCHM(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -494,7 +495,8 @@ class SEGARCHM(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/gas/gas.py
+++ b/pyflux/gas/gas.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -421,6 +420,7 @@ class GAS(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -474,7 +474,8 @@ class GAS(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -563,7 +564,8 @@ class GAS(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/gas/gasllm.py
+++ b/pyflux/gas/gasllm.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -376,6 +375,7 @@ class GASLLEV(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -429,7 +429,8 @@ class GASLLEV(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -517,7 +518,8 @@ class GASLLEV(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/gas/gasllt.py
+++ b/pyflux/gas/gasllt.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -391,6 +390,7 @@ class GASLLT(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -449,7 +449,8 @@ class GASLLT(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -537,7 +538,8 @@ class GASLLT(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/gas/gasrank.py
+++ b/pyflux/gas/gasrank.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -335,6 +334,7 @@ class GASRank(tsm.TSM):
         return self.family.neg_loglikelihood(Y,self.link(theta),model_scale,model_shape,model_skewness)
 
     def plot_abilities_one_components(self, team_ids, **kwargs):
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(15,5))
 
@@ -366,6 +366,7 @@ class GASRank(tsm.TSM):
             plt.show()
 
     def plot_abilities_two_components(self, team_ids, component_id=0, **kwargs):
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(15,5))
 

--- a/pyflux/gas/gasreg.py
+++ b/pyflux/gas/gasreg.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 from patsy import dmatrices, dmatrix, demo_data
 
@@ -269,6 +268,7 @@ class GASReg(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -326,7 +326,8 @@ class GASReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -389,7 +390,8 @@ class GASReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/gas/gasx.py
+++ b/pyflux/gas/gasx.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 import scipy.special as sp
-import matplotlib.pyplot as plt
 import seaborn as sns
 from patsy import dmatrices, dmatrix, demo_data
 
@@ -446,6 +445,7 @@ class GASX(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -501,7 +501,8 @@ class GASX(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -596,7 +597,8 @@ class GASX(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/gpnarx/gpnarx.py
+++ b/pyflux/gpnarx/gpnarx.py
@@ -8,7 +8,6 @@ import scipy.linalg as la
 import scipy.sparse as sp
 import scipy.stats as ss
 from scipy.stats import multivariate_normal
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import arma
@@ -276,6 +275,7 @@ class GPNARX(tsm.TSM):
         ----------
         None (plots the fit of the function)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -334,7 +334,8 @@ class GPNARX(tsm.TSM):
         ----------
         - Plot of the forecast
         - Error bars, forecasted_values, plot_values, plot_index
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -422,7 +423,8 @@ class GPNARX(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/inference/bbvi.py
+++ b/pyflux/inference/bbvi.py
@@ -3,8 +3,6 @@ if sys.version_info < (3,):
     range = xrange
 
 import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.mlab as mlab
 import scipy.stats as ss
 
 from .stoch_optim import RMSProp, ADAM

--- a/pyflux/latent_variables.py
+++ b/pyflux/latent_variables.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-import matplotlib.mlab as mlab
 from matplotlib import rcParams
 import seaborn as sns
 
@@ -209,6 +207,9 @@ class LatentVariables(object):
             self.z_list[no].start = values[no]
 
     def plot_z(self,indices=None,figsize=(15,5),loc=1):
+        import matplotlib.pyplot as plt
+        import matplotlib.mlab as mlab
+
         plt.figure(figsize=figsize) 
         for z in range(1,len(self.z_list)+1):
             if indices is not None and z-1 not in indices:
@@ -237,6 +238,9 @@ class LatentVariables(object):
         plt.show()
 
     def trace_plot(self,figsize=(15,15)):
+        import matplotlib.pyplot as plt
+        import matplotlib.mlab as mlab
+
         if hasattr(self.z_list[0], 'sample'):
             fig = plt.figure(figsize=figsize)
             
@@ -301,6 +305,8 @@ class LatentVariable(object):
         self.q = q
 
     def plot_z(self,figsize=(15,5)):
+        import matplotlib.pyplot as plt
+
         if hasattr(self, 'sample'):
             sns.distplot(self.sample, rug=False, hist=False,label=self.method + ' estimate of ' + self.name)
 

--- a/pyflux/ssm/dar.py
+++ b/pyflux/ssm/dar.py
@@ -6,7 +6,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 from patsy import dmatrices, dmatrix, demo_data
 
@@ -200,7 +199,8 @@ class DAR(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -259,6 +259,7 @@ class DAR(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
         series_type = kwargs.get('series_type','Smoothed')
@@ -395,7 +396,8 @@ class DAR(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/ssm/dynlin.py
+++ b/pyflux/ssm/dynlin.py
@@ -6,7 +6,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 from patsy import dmatrices, dmatrix, demo_data
 
@@ -178,7 +177,8 @@ class DynReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -232,6 +232,7 @@ class DynReg(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
         series_type = kwargs.get('series_type','Smoothed')
@@ -377,7 +378,8 @@ class DynReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/ssm/llm.py
+++ b/pyflux/ssm/llm.py
@@ -6,7 +6,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -169,7 +168,8 @@ class LLEV(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -211,6 +211,7 @@ class LLEV(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
         series_type = kwargs.get('series_type','Smoothed')
@@ -334,7 +335,8 @@ class LLEV(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/ssm/llt.py
+++ b/pyflux/ssm/llt.py
@@ -6,7 +6,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 
 from .. import inference as ifr
@@ -177,7 +176,8 @@ class LLT(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -218,6 +218,7 @@ class LLT(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
         series_type = kwargs.get('series_type','Smoothed')
@@ -354,7 +355,8 @@ class LLT(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/ssm/ndynlin.py
+++ b/pyflux/ssm/ndynlin.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 from scipy import optimize
 import seaborn as sns
 from patsy import dmatrices, dmatrix, demo_data
@@ -984,7 +983,8 @@ class NDynReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -1060,6 +1060,7 @@ class NDynReg(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -1191,7 +1192,8 @@ class NDynReg(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/ssm/nllm.py
+++ b/pyflux/ssm/nllm.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 from scipy import optimize
-import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation, writers
 import seaborn as sns
 
@@ -991,7 +990,8 @@ class NLLEV(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as pltv
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -1048,6 +1048,7 @@ class NLLEV(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -1177,7 +1178,8 @@ class NLLEV(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/ssm/nllt.py
+++ b/pyflux/ssm/nllt.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 import scipy.stats as ss
 from scipy import optimize
-import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 import seaborn as sns
 
@@ -1025,7 +1024,8 @@ class NLLT(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -1090,6 +1090,7 @@ class NLLT(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -1221,7 +1222,8 @@ class NLLT(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 

--- a/pyflux/tsm.py
+++ b/pyflux/tsm.py
@@ -6,8 +6,6 @@ if sys.version_info < (3,):
 
 import numpy as np
 from scipy import optimize
-import matplotlib.pyplot as plt
-import matplotlib.mlab as mlab
 import seaborn as sns
 import numdifftools as nd
 import pandas as pd

--- a/pyflux/var/var.py
+++ b/pyflux/var/var.py
@@ -5,7 +5,6 @@ if sys.version_info < (3,):
 import numpy as np
 import pandas as pd
 import scipy.stats as ss
-import matplotlib.pyplot as plt
 import seaborn as sns
 import datetime
 
@@ -434,6 +433,7 @@ class VAR(tsm.TSM):
         ----------
         None (plots data and the fit)
         """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -468,7 +468,8 @@ class VAR(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast
-        """             
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 
@@ -582,7 +583,8 @@ class VAR(tsm.TSM):
         Returns
         ----------
         - Plot of the forecast against data 
-        """     
+        """
+        import matplotlib.pyplot as plt
 
         figsize = kwargs.get('figsize',(10,7))
 


### PR DESCRIPTION
Right now it's not possible to use pyflux in a python environment which is not configured for Tk, which is the case for most server environments:
```
Traceback (most recent call last):
  File "...", line 1, in <module>
    import pyflux as pf
  File ".../python/lib/python2.7/site-packages/pyflux/__init__.py", line 5, in <module>
    from .arma import *
  File ".../python/lib/python2.7/site-packages/pyflux/arma/__init__.py", line 1, in <module>
    from .arma import ARIMA
  File ".../python/lib/python2.7/site-packages/pyflux/arma/arma.py", line 8, in <module>
    import matplotlib.pyplot as plt
  File ".../python/lib/python2.7/site-packages/matplotlib/pyplot.py", line 114, in <module>
    _backend_mod, new_figure_manager, draw_if_interactive, _show = pylab_setup()
  File ".../python/lib/python2.7/site-packages/matplotlib/backends/__init__.py", line 32, in pylab_setup
    globals(),locals(),[backend_name],0)
  File ".../python/lib/python2.7/site-packages/matplotlib/backends/backend_tkagg.py", line 6, in <module>
    from matplotlib.externals.six.moves import tkinter as Tk
  File ".../python/lib/python2.7/site-packages/matplotlib/externals/six.py", line 199, in load_module
    mod = mod._resolve()
  File ".../python/lib/python2.7/site-packages/matplotlib/externals/six.py", line 113, in _resolve
    return _import_module(self.mod)
  File ".../python/lib/python2.7/site-packages/matplotlib/externals/six.py", line 80, in _import_module
    __import__(name)
  File ".../python/lib/python2.7/lib-tk/Tkinter.py", line 39, in <module>
      import _tkinter # If this fails your Python may not be configured for Tk
ImportError: No module named _tkinter
```

This PR moves all `matplotlib` imports from the global scope into the different plotting functions so that Tkinter is only required if you actually use the plotting capabilities of pyflux.