### PR TITLE
Wrong step width in array slicing

### DIFF
--- a/pyflux/var/var.py
+++ b/pyflux/var/var.py
@@ -529,7 +529,7 @@ class VAR(tsm.TSM):
         predictions = []
 
         for t in range(0,h):
-            new_data = self.data_original.iloc[::-h+t]
+            new_data = self.data_original.iloc[:-h+t]
             x = VAR(lags=self.lags, integ=self.integ, data=new_data)
             
             if fit_once is False:


### PR DESCRIPTION
Line 532 new_data = self.data_original.iloc[::-h+t]
was buggy. Written this way -h+t is the step width. Resulting in "Singular Matrix" in np.linalg.inv if h is larger than 5 (in my problem).