### PR TITLE
added warning that pyflux.com contains mal-/adware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PyFlux
 [![PyFlux](http://pyflux.com/pyflux.png)](http://github.com/RJT1990/pyflux)
 
+> Attention: This project no longer lives at pyflux.com! Pyflux.com contains mal-/adware!
+
 [![Join the chat at https://gitter.im/RJT1990/pyflux](https://badges.gitter.im/RJT1990/pyflux.svg)](https://gitter.im/RJT1990/pyflux?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![PyPI version](https://badge.fury.io/py/pyflux.svg)](https://badge.fury.io/py/pyflux)
 [![Documentation Status](https://readthedocs.org/projects/pyflux/badge/?version=latest)](http://pyflux.readthedocs.io/en/latest/?badge=latest)
@@ -65,4 +67,5 @@ PyFlux is still alpha software so results should be treated with care, but citat
 
 > Ross Taylor. 2016.
 > _PyFlux: An open source time series library for Python_
-> http://www.pyflux.com
+
+


### PR DESCRIPTION
hey there,

it appears that the pyflux.com contains the gsafe adware that tries to install a plugin in user browers. I put a warning at the top of the project readme.

I removed pyflux.com from Citation, but I did not check the rest of your site for links to pyflux.com

Best